### PR TITLE
Fix --canvas-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"name": "Retroma",
 	"version": "2.7.0",
-	"minAppVersion": "1.0.0",
+	"minAppVersion": "1.13.0",
 	"author": "emarpiee",
 	"authorUrl": "https://github.com/emarpiee"
 }

--- a/theme.css
+++ b/theme.css
@@ -1328,21 +1328,18 @@ tr:last-child td:last-child {
 }
 
 .canvas-node-container {
-  border: var(--retroma-canvas-card-border-width) solid rgb(var(--canvas-color));
+  border: var(--retroma-canvas-card-border-width) solid var(--canvas-color);
   background: var(--canvas-color);
 }
 
 .canvas-node-container:has(.markdown-embed-link),
 .canvas-node-container:has(.image-embed) {
   border: var(--retroma-canvas-card-embed-border-width) solid
-    rgb(var(--canvas-color)) !important;
+    var(--canvas-color) !important;
 }
 
 .canvas-node.is-themed .canvas-node-content {
-  background: rgba(
-    var(--canvas-color),
-    var(--retroma-canvas-node-content-bg-opacity)
-  );
+  background: color-mix(in srgb, var(--canvas-color) calc(var(--retroma-canvas-node-content-bg-opacity) * 100%), transparent);
 }
 
 .canvas .markdown-preview-view {


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--canvas-color` (and `--canvas-color-1` through `--canvas-color-6`) works. It now provides a valid CSS color value (e.g. `#e93147`) instead of a bare RGB triplet (`233, 49, 71`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--canvas-color-1: 255, 0, 128;
/* After */
--canvas-color-1: rgb(255, 0, 128);
```

**2. Wrapping `var(--canvas-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--canvas-color), 0.1);
/* After */
background: color-mix(in srgb, var(--canvas-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--canvas-color` / `--canvas-color-N` declarations with `rgb()`
- Replaced `rgb(var(--canvas-color))` with `var(--canvas-color)`
- Replaced `rgba(var(--canvas-color), <alpha>)` with `color-mix(in srgb, var(--canvas-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
