### PR TITLE
Fix base cards not being centered on desktop with default settings

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -3299,6 +3299,10 @@ a.tag:hover,
 	background: var(--rtm-bg-paper);
 }
 
+.bases-view[data-view-type="cards"] {
+  scrollbar-gutter: stable both-edges;
+}
+
 .bases-view .maplibregl-popup-content {
 	background: var(--rtm-bases-maps-popup-bg);
 	border: var(--rtm-embed-border);


### PR DESCRIPTION
I noticed that on desktop, without any CSS snippets and using the default Retroma config, the card view of bases has this extra gap to the right (pictured below):

<img width="761" height="546" alt="image" src="https://github.com/user-attachments/assets/54e2c05a-1878-4fc0-9c6d-a6d48fe4f489" />

This seems to be because of Obsidian using `scrollbar-gutter: stable` by default. I think this is pretty ugly default behavior, but I get not wanting scrollbars to cause widths to change, so I figured a reasonable compromise would be to use `scrollbar-gutter: stable both-edges` on base cards to have that gap appear on both sides so that the content is still centered. With this change, the above base looks like this:

<img width="747" height="520" alt="image" src="https://github.com/user-attachments/assets/54d2334c-2beb-4e7d-ba94-b53ee3f4aae6" />

This PR adds that rule. If you don't want the gaps at all, `scrollbar-gutter: auto` on base cards is another option that would remove the gap entirely but possibly cause the cards to shift when a scrollbar appears.